### PR TITLE
Improve changes logic and add test case

### DIFF
--- a/tests/changes-test.v1
+++ b/tests/changes-test.v1
@@ -1,0 +1,25 @@
+PACKAGE NAME: no-changes
+PACKAGE VERSION: 1.0.0
+RECIPE NAME: no-changes
+LICENSE: GPLv2+
+
+PACKAGE NAME: changes-version
+PACKAGE VERSION: 1.1.1
+RECIPE NAME: changes-version
+LICENSE: LGPLv2.1+ & GPLv2+
+
+PACKAGE NAME: changes-license
+PACKAGE VERSION: 1.0+gitAUTOINC+dad22588d7
+RECIPE NAME: changes-license
+LICENSE: MPL-2.0
+
+PACKAGE NAME: changes-license-ver
+PACKAGE VERSION: 2.0.0
+RECIPE NAME: changes-license-ver
+LICENSE: Apache-2.0
+
+PACKAGE NAME: packagedropped
+PACKAGE VERSION: 2.0.0
+RECIPE NAME: packagedropped
+LICENSE: MIT
+

--- a/tests/changes-test.v2
+++ b/tests/changes-test.v2
@@ -1,0 +1,25 @@
+PACKAGE NAME: no-changes
+PACKAGE VERSION: 1.0.0
+RECIPE NAME: no-changes
+LICENSE: GPLv2+
+
+PACKAGE NAME: changes-version
+PACKAGE VERSION: 2.2.2-changed
+RECIPE NAME: changes-version
+LICENSE: LGPLv2.1+ & GPLv2+
+
+PACKAGE NAME: changes-license
+PACKAGE VERSION: 1.0+gitAUTOINC+dad22588d7
+RECIPE NAME: changes-license
+LICENSE: MIT-CHANGED
+
+PACKAGE NAME: changes-license-ver
+PACKAGE VERSION: 3.2.1-changed
+RECIPE NAME: changes-license
+LICENSE: MIT-changed
+
+PACKAGE NAME: new-package
+PACKAGE VERSION: 0.0.1
+RECIPE NAME: new-package
+LICENSE: Apache-2.0
+

--- a/tests/test-changes.csv
+++ b/tests/test-changes.csv
@@ -1,0 +1,7 @@
+package,prev_ver,prev_recipe,prev_license,curr_ver,curr_recipe,curr_license,change,version_change,license_change,package_change
+no-changes,1.0.0,no-changes,GPLv2+,1.0.0,no-changes,GPLv2+,n,n,n,n
+changes-version,1.1.1,changes-version,LGPLv2.1+ & GPLv2+,2.2.2-changed,changes-version,LGPLv2.1+ & GPLv2+,y,y,n,n
+changes-license,1.0+gitAUTOINC+dad22588d7,changes-license,MPL-2.0,1.0+gitAUTOINC+dad22588d7,changes-license,MIT-CHANGED,y,n,y,n
+changes-license-ver,2.0.0,changes-license-ver,Apache-2.0,3.2.1-changed,changes-license,MIT-changed,y,y,y,n
+packagedropped,2.0.0,packagedropped,MIT,,,,y,n,n,dropped package
+new-package,,,,0.0.1,new-package,Apache-2.0,y,n,n,new package

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -54,3 +54,13 @@ def test_changes_3packages_v2(tmpdir):
     tmp_outfile = str(tmpdir.join("out.cvs"))
     ret = os.system("python licensetool.py changes tests/3-packages.manifest tests/3-packages.manifest.v2 " + tmp_outfile )
     assert ret == 0
+
+# Success case
+def test_changes_changes_v1_v2(tmpdir):
+    tmp_outfile = str(tmpdir.join("out.cvs"))
+    ret = os.system("python licensetool.py changes tests/changes-test.v1 tests/changes-test.v2 " + tmp_outfile )
+    assert ret == 0
+    # Compare result, too
+    ref_df = pd.read_csv("tests/test-changes.csv")
+    result_df = pd.read_csv(tmp_outfile)
+    assert result_df.equals(ref_df)


### PR DESCRIPTION
Improved logic for changes to highlight the changes in separate
columns, which can be filtered or used as pivot table data.

Added printouts of package number where possible issue is found
when parsing.

97% test coverage as before
10/10 in pylint