### PR TITLE
fix pylint warning

### DIFF
--- a/licensetool.py
+++ b/licensetool.py
@@ -224,6 +224,7 @@ def generate_excel(output, styled):
     writer = pd.ExcelWriter(output, engine='openpyxl') # pylint: disable=abstract-class-instantiated
     styled.to_excel(writer, sheet_name='Sheet1', index=False)
     # Get the xlsxwriter workbook and worksheet objects.
+    # pylint: disable=E1101
     workbook = writer.book
     worksheet = workbook.active
     worksheet.auto_filter.ref = worksheet.dimensions


### PR DESCRIPTION
Fix for:

```
(venv) C:\Users\JanneKiiskilä\git\licensetool>python -m pylint licensetool.py
************* Module licensetool
licensetool.py:227:15: E1101: Instance of 'ExcelWriter' has no 'book' member (no-member)

------------------------------------------------------------------
Your code has been rated at 9.70/10 (previous run: 9.70/10, +0.00)
```
