### PR TITLE
pysh-check compliancy, Python 3.10 workarounds

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -11,18 +11,16 @@ jobs:
       - run: pip install --editable .
       - run: pytest -v -o junit_family=xunit1 --cov=. --cov-report xml:coverage.xml --cov-report html:test-results/cov_html --junitxml=xunit-reports/xunit.xml
       - run: pylint licensetool.py tests/*.py
-#  run-pysh-check:
-#    runs-on: ubuntu-22.04
-#    env:
-#      PA_TOKEN: ${{ secrets.ACCESS_TOKEN }} # IzumaBOT Access Token
-#    steps:
-#      - uses: actions/checkout@v3
-#      # Install pyshcheck tooling
-#      - run: sudo apt install pycodestyle pydocstyle black
-#      # git instead of rules to use access token
-#      - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
-#      - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
-#      - run: git config --list
-#      - run: git clone git@github.com:PelionIoT/scripts-internal.git
-#      - run: echo "." >scripts-internal/.nopyshcheck
-#      - run: scripts-internal/pysh-check/pysh-check.sh --workdir .
+  run-pysh-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      # Install pyshcheck tooling
+      - run: sudo apt install pycodestyle pydocstyle black
+      # git instead of rules to use access token
+      - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
+      - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
+      - run: git config --list
+      - run: git clone git@github.com:PelionIoT/scripts-internal.git
+      - run: echo "." >scripts-internal/.nopyshcheck
+      - run: scripts-internal/pysh-check/pysh-check.sh --workdir .

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ You need to have Python version 3.6 (or newer) installed in your system. This ha
 
 We highly recommend using a [Python virtual environment](https://docs.python.org/3/tutorial/venv.html).
 
+Python 3.10 will give you unfortunately a lot of warnings. They just love deprecating APIs in the Python world, don't they?
+
 ## User installation
 
 ```
@@ -35,6 +37,8 @@ Run the init script, it will do everything for you.
 
 
 ## Usage
+
+The license file is generated as part of the Yocto build. In Foundries.io LmP-build you can find the file under `<build-folder>/deploy/licenses/<image-name-target-name>/license.manifest`.
 
 ### Generate CSV-formatted license file
 

--- a/dev-init.sh
+++ b/dev-init.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 # ----------------------------------------------------------------------------
 # Copyright 2021 Pelion
+# Copyright 2021 Izuma Networks
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -23,9 +24,10 @@ if [[ ! -d venv ]]; then
     python3 -m venv venv
 fi
 
+# shellcheck disable=SC1091
 source venv/bin/activate
 
-if [pip show licensetool]; then
+if [[ $(pip show licensetool) ]]; then
     pip uninstall licensetool --yes
 fi
 pip install --editable .

--- a/licensetool.py
+++ b/licensetool.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2021, Pelion Limited and affiliates.
+# Copyright (c) 2022 Izuma Networks
+#
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +17,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A tool for dealing with Yocto license manifest files, converting them to
-CSV/Excel-format, optionally with change information."""
+
+"""
+A tool for dealing with Yocto license manifest files.
+
+This tool can converting them to CSV/Excel-format,
+optionally with change information.
+"""
+
 
 import sys
 import os
@@ -41,7 +49,7 @@ _CURR_LIC = "Current license"
 _CURR_VER = "Current version"
 _CURR_REC = "Current recipe"
 
-_MARK_CHG = "y"                 # What we use to mark changes
+_MARK_CHG = "y"  # What we use to mark changes
 _PKG = "Package"
 _CHG = "Change"
 _PKG_ADD = "Package added"
@@ -50,6 +58,7 @@ _LIC_CHG = "License change"
 _VER_CHG = "Version change"
 
 _DATA_SHEET_NAME = "sheet1"
+
 
 def _print_help():
 
@@ -60,29 +69,39 @@ def _print_help():
     print("   For example license-tool.py list license.manifest licenses ")
     print("   Will generate licenses.csv and licenses.xlsx files.")
     print("")
-    print("license-tool.py changes <previous manifest file> <current manifest file> "
-          "<output file>")
-    print("   Generate a CSV and Excel-formatted version based on two Yocto manifest files that"
-          " highlights the changes")
-    print("   For example license-tool.py changes license.manifest.v82 license.manifest.v83 "
-          "license-changes-v82-v83")
-    print("   Will generate license-changes-v82-v83.csv and license-changes-v82-v83.xlsx files.")
+    print(
+        "license-tool.py changes <previous manifest file>"
+        " <current manifest file> <output file>"
+    )
+    print(
+        "   Generate a CSV and Excel-formatted version based on two Yocto"
+        " manifest files that highlights the changes"
+    )
+    print(
+        "   For example license-tool.py changes license.manifest.v82"
+        " license.manifest.v83 license-changes-v82-v83"
+    )
+    print(
+        "   Will generate license-changes-v82-v83.csv and "
+        " license-changes-v82-v83.xlsx files."
+    )
     print("")
     print("Optional:")
     print(" --verbose   verbose output")
     print(" --debug     debug level output")
     print(" --force     enable overwriting of existing output files")
 
-# read_manifest_file - read Yocto license manifest and turn into a Panda's dataframe
-#                         and a status dictionary.
+
+# read_manifest_file - read Yocto license manifest and turn into a Panda's
+#                      dataframe and a status dictionary.
 #
 def read_manifest_file(input_file):
-
     """Read manifest file and return a Panda's dataframe ."""
-
-    pattern = re.compile("PACKAGE NAME: (.*)\nPACKAGE VERSION: (.*)\nRECIPE NAME: (.*)\n"
-                         "LICENSE: (.*)\n\n")
-    with open(input_file, "r", encoding='utf8') as f_h:
+    pattern = re.compile(
+        "PACKAGE NAME: (.*)\nPACKAGE VERSION: (.*)\nRECIPE NAME: (.*)\n"
+        "LICENSE: (.*)\n\n"
+    )
+    with open(input_file, "r", encoding="utf8") as f_h:
         data = f_h.read()
         # Create empty dataframe
         column_names = [_PKG, "version", "recipe", "license"]
@@ -92,40 +111,61 @@ def read_manifest_file(input_file):
         errors = False
         prew = 0
         for info_field in re.finditer(pattern, data):
-            package_count+=1
+            package_count += 1
             if info_field.span()[0] != prew:
-                print("ERROR - Invalid content in the file, got " + str(package_count)
-                      + " packages.")
-                errors = True # there is some content not matching the pattern in file.
+                print(
+                    "ERROR - Invalid content in the file, got "
+                    + str(package_count)
+                    + " packages."
+                )
+                # There is some content not matching the pattern in file.
+                errors = True
             prew = info_field.span()[1]
 
-            new_row = {column_names[0]: info_field.group(1),
-                    column_names[1]: info_field.group(2),
-                    column_names[2]: info_field.group(3),
-                    column_names[3]: info_field.group(4)}
+            new_row = {
+                column_names[0]: info_field.group(1),
+                column_names[1]: info_field.group(2),
+                column_names[2]: info_field.group(3),
+                column_names[3]: info_field.group(4),
+            }
             d_f = d_f.append(new_row, ignore_index=True)
 
-        if package_count == 0: # needs to have at least one package or it is an error
+        if (
+            package_count == 0
+        ):  # needs to have at least one package or it is an error
             print("Package count is zero")
             errors = True
 
         data_len = len(data)
         if data_len != prew:
             # if not all data was matched it is an error
-            print("ERROR - Invalid content at end of file, got " + str(package_count)
-                   + " packages.")
+            print(
+                "ERROR - Invalid content at end of file, got "
+                + str(package_count)
+                + " packages."
+            )
             errors = True
 
         num_lines = sum(1 for line in data.split("\n"))
-        status = {"lines": num_lines, "packages": package_count, "errors": errors}
+        status = {
+            "lines": num_lines,
+            "packages": package_count,
+            "errors": errors,
+        }
     return d_f, status
+
 
 # gen_list - generate list-formatted files from a license manifest file
 #            filenames of input file and output filename base needed as
 #            parameters. Two output files are created, file.csv and .xlsx.
 #
 def gen_list(inputfile, outputfile):
-    """gen_list - generate list formatted output (.csv and .xlsx) from manifest file."""
+    """
+    gen_list - generate list.
+
+    generate list formatted output (.csv and .xlsx) from
+    manifest file.
+    """
     logging.debug("gen_list: '%s','%s'", inputfile, outputfile)
 
     # Covert the manifest to a Pandas dataframe
@@ -133,27 +173,31 @@ def gen_list(inputfile, outputfile):
 
     # Export CSV, if no errors noticed
     if status["errors"] is False:
-        d_f.to_csv(outputfile + _CSV, index = False)
-        generate_excel(outputfile + _XLS,
+        d_f.to_csv(outputfile + _CSV, index=False)
+        generate_excel(
+            outputfile + _XLS,
             d_f.style,
-            template_file="excel-template-list.xlsx")
+            template_file="excel-template-list.xlsx",
+        )
     else:
         print("ERROR - could not process license manifest file " + inputfile)
-        sys.exit(71) # EPROTO
-    print(inputfile + " " + str(status) )
+        sys.exit(71)  # EPROTO
+    print(inputfile + " " + str(status))
+
 
 # init_change_summary  - initialize change summary dict
 #
 def init_change_summary():
-    """Initalize and return a change_summary dict."""
+    """Init and return a change_summary dict."""
     logging.info("Finding changes...")
     change_summary = {
-        _VER_CHG : 0,
-        _LIC_CHG : 0,
-        _PKG_ADD : 0,
-        _PKG_REM : 0,
+        _VER_CHG: 0,
+        _LIC_CHG: 0,
+        _PKG_ADD: 0,
+        _PKG_REM: 0,
     }
     return change_summary
+
 
 #
 # print_change_summary - print out a summary of the changes
@@ -162,63 +206,83 @@ def init_change_summary():
 def print_change_summary(chg_sum):
     """Print change summary from given dict."""
     print("")
-    print("Total changes  : ", (
-        chg_sum[_PKG_ADD] +
-        chg_sum[_PKG_REM] +
-        chg_sum[_LIC_CHG] +
-        chg_sum[_VER_CHG] ))
+    print(
+        "Total changes  : ",
+        (
+            chg_sum[_PKG_ADD]
+            + chg_sum[_PKG_REM]
+            + chg_sum[_LIC_CHG]
+            + chg_sum[_VER_CHG]
+        ),
+    )
     print("Package changes: ", (chg_sum[_PKG_ADD] + chg_sum[_PKG_REM]))
     print("- Added        : ", chg_sum[_PKG_ADD])
     print("- Removed      : ", chg_sum[_PKG_REM])
     print("License changes: ", chg_sum[_LIC_CHG])
     print("Version changes: ", chg_sum[_VER_CHG])
 
+
 # read_and_merge_manifests  - read previous and current manifest files
 #                             and return a merged dataframe with their content.
 
+
 def read_and_merge_manifests(previous, current):
-    """Read previous and current manifest, return as two dataframes"""
+    """Read previous and current manifest, return as two dataframes."""
     d_f_prev, status_prev = read_manifest_file(previous)
     d_f_prev.rename(
-        columns={"version": _PREV_VER, "license": _PREV_LIC, "recipe": _PREV_REC},
-        inplace=True
+        columns={
+            "version": _PREV_VER,
+            "license": _PREV_LIC,
+            "recipe": _PREV_REC,
+        },
+        inplace=True,
     )
     if status_prev["errors"] is True:
         print("ERROR - handling of '" + previous + "' failed.")
-        sys.exit(71) # EPROTO
-    print(previous + " " + str(status_prev) )
+        sys.exit(71)  # EPROTO
+    print(previous + " " + str(status_prev))
 
     d_f_curr, status_curr = read_manifest_file(current)
     d_f_curr.rename(
-        columns={"version": _CURR_VER, "license": _CURR_LIC, "recipe": _CURR_REC},
-        inplace=True
+        columns={
+            "version": _CURR_VER,
+            "license": _CURR_LIC,
+            "recipe": _CURR_REC,
+        },
+        inplace=True,
     )
     if status_curr["errors"] is True:
         print("ERROR - handling of '" + current + "' failed.")
-        sys.exit(71) # EPROTO
-    print(current + " " + str(status_curr) )
+        sys.exit(71)  # EPROTO
+    print(current + " " + str(status_curr))
 
     # 1st create a merged table that has both previous and current information
     logging.info("Merging dataframes...")
-    d_f_combo = pd.merge(d_f_prev, d_f_curr, on = _PKG, how = "outer")
+    d_f_combo = pd.merge(d_f_prev, d_f_curr, on=_PKG, how="outer")
     logging.debug(d_f_combo)
     return d_f_combo
 
-# gen_changes - generate change information based on two Yocto license manifest files
+
+# gen_changes - generate change information based on two Yocto
+#               license manifest files
 #
 def gen_changes(previous, current, output):
-    """gen_list - generate list formatted change output (.csv and .xlsx) from 2 manifest files."""
+    """
+    gen_list - generate list.
 
+    Generate list formatted change output (.csv and .xlsx)
+    from 2 manifest files.
+    """
     logging.debug("gen_changes: '%s', '%s', '%s'", previous, current, output)
     # Read the manifests, get them merged into one combined dataframe
     d_f_combo = read_and_merge_manifests(previous, current)
 
-    # With that, we can now start going it through and add the "changes" columns
-    # to highlight what has changed.
-    # Not going to consider recipe change a change worth high-lighting, that is not relevant from
-    # Third Party IP point of view.
+    # With that, we can now start going it through and add the "changes"
+    # columns to highlight what has changed.
+    # Not going to consider recipe change a change worth high-lighting,
+    # that is not relevant from Third Party IP point of view.
 
-    d_f_combo[[_CHG, _VER_CHG,_LIC_CHG, _PKG_ADD, _PKG_REM]] = ""
+    d_f_combo[[_CHG, _VER_CHG, _LIC_CHG, _PKG_ADD, _PKG_REM]] = ""
     i = 0
     rows = d_f_combo.shape[0]
     styled = d_f_combo.style
@@ -226,74 +290,133 @@ def gen_changes(previous, current, output):
     while i < rows:
         # Check package appearing, start by setting change is "n"
         package_change = False
-        if pd.isna(d_f_combo.at[i, _PREV_REC]): # NaN
+        if pd.isna(d_f_combo.at[i, _PREV_REC]):  # NaN
             d_f_combo.at[i, _CHG] = _MARK_CHG
             d_f_combo.at[i, _PKG_ADD] = _MARK_CHG
-            styled = styled.apply(style_single_cell, row=i,
+            styled = styled.apply(
+                style_single_cell,
+                row=i,
                 column=d_f_combo.columns.get_loc(_CURR_REC),
-                color="yellow", axis=None)
-            styled = styled.apply(style_single_cell, row=i,
+                color="yellow",
+                axis=None,
+            )
+            styled = styled.apply(
+                style_single_cell,
+                row=i,
                 column=d_f_combo.columns.get_loc(_PKG),
-                color="yellow", axis=None)
-            styled = styled.apply(style_single_cell, row=i,
+                color="yellow",
+                axis=None,
+            )
+            styled = styled.apply(
+                style_single_cell,
+                row=i,
                 column=d_f_combo.columns.get_loc(_CURR_VER),
-                color="yellow", axis=None)
-            styled = styled.apply(style_single_cell, row=i,
+                color="yellow",
+                axis=None,
+            )
+            styled = styled.apply(
+                style_single_cell,
+                row=i,
                 column=d_f_combo.columns.get_loc(_CURR_LIC),
-                color="yellow", axis=None)
+                color="yellow",
+                axis=None,
+            )
             package_change = True
             change_summary[_PKG_ADD] += 1
         # Package removed
-        if package_change is False and pd.isna(d_f_combo.at[i, _CURR_REC]): # NaN
+        if package_change is False and pd.isna(
+            d_f_combo.at[i, _CURR_REC]
+        ):  # NaN
             d_f_combo.at[i, _CHG] = _MARK_CHG
             d_f_combo.at[i, _PKG_REM] = _MARK_CHG
-            styled = styled.apply(style_single_cell, row=i,
+            styled = styled.apply(
+                style_single_cell,
+                row=i,
                 column=d_f_combo.columns.get_loc(_PREV_REC),
-                color="yellow", axis=None)
-            styled = styled.apply(style_single_cell, row=i,
+                color="yellow",
+                axis=None,
+            )
+            styled = styled.apply(
+                style_single_cell,
+                row=i,
                 column=d_f_combo.columns.get_loc(_PREV_VER),
-                color="yellow", axis=None)
-            styled = styled.apply(style_single_cell, row=i,
+                color="yellow",
+                axis=None,
+            )
+            styled = styled.apply(
+                style_single_cell,
+                row=i,
                 column=d_f_combo.columns.get_loc(_PKG),
-                color="yellow", axis=None)
-            styled = styled.apply(style_single_cell, row=i,
+                color="yellow",
+                axis=None,
+            )
+            styled = styled.apply(
+                style_single_cell,
+                row=i,
                 column=d_f_combo.columns.get_loc(_PREV_LIC),
-                color="yellow", axis=None)
+                color="yellow",
+                axis=None,
+            )
             package_change = True
-            change_summary[_PKG_REM] +=1
+            change_summary[_PKG_REM] += 1
         # Version change
-        if package_change is False and d_f_combo.at[i, _PREV_VER] != d_f_combo.at[i, _CURR_VER]:
+        if (
+            package_change is False
+            and d_f_combo.at[i, _PREV_VER] != d_f_combo.at[i, _CURR_VER]
+        ):
             d_f_combo.at[i, _CHG] = _MARK_CHG
             d_f_combo.at[i, _VER_CHG] = _MARK_CHG
-            styled = styled.apply(style_single_cell, row=i,
+            styled = styled.apply(
+                style_single_cell,
+                row=i,
                 column=d_f_combo.columns.get_loc(_PREV_VER),
-                color="green", axis=None)
-            styled = styled.apply(style_single_cell, row=i,
+                color="green",
+                axis=None,
+            )
+            styled = styled.apply(
+                style_single_cell,
+                row=i,
                 column=d_f_combo.columns.get_loc(_CURR_VER),
-                color="green", axis=None)
-            change_summary[_VER_CHG] +=1
+                color="green",
+                axis=None,
+            )
+            change_summary[_VER_CHG] += 1
         # License change
-        if package_change is False and \
-           d_f_combo.at[i, _PREV_LIC] != d_f_combo.at[i, _CURR_LIC]:
+        if (
+            package_change is False
+            and d_f_combo.at[i, _PREV_LIC] != d_f_combo.at[i, _CURR_LIC]
+        ):
             d_f_combo.at[i, _CHG] = _MARK_CHG
             d_f_combo.at[i, _LIC_CHG] = _MARK_CHG
-            styled = styled.apply(style_single_cell, row=i,
+            styled = styled.apply(
+                style_single_cell,
+                row=i,
                 column=d_f_combo.columns.get_loc(_PREV_LIC),
-                color="red", axis=None)
-            styled = styled.apply(style_single_cell, row=i,
+                color="red",
+                axis=None,
+            )
+            styled = styled.apply(
+                style_single_cell,
+                row=i,
                 column=d_f_combo.columns.get_loc(_CURR_LIC),
-                color="red", axis=None)
-            change_summary[_LIC_CHG] +=1
-        # No changes cases is the default, as we set all change columns to n at start
+                color="red",
+                axis=None,
+            )
+            change_summary[_LIC_CHG] += 1
+        # No changes cases is the default, as we set all
+        # change columns to n at start
         i = i + 1
     # Export result out
     logging.info("Export CSV: %s ", output + _CSV)
     d_f_combo.to_csv(path_or_buf=output + _CSV, index=False)
     logging.info("Export Excel: %s", output + _XLS)
-    generate_excel(output=output + _XLS,
+    generate_excel(
+        output=output + _XLS,
         styled=styled,
-        template_file="excel-template-changes.xlsx")
+        template_file="excel-template-changes.xlsx",
+    )
     print_change_summary(change_summary)
+
 
 #
 # generate_excel   output = output filename,
@@ -301,10 +424,9 @@ def gen_changes(previous, current, output):
 #
 def generate_excel(output, styled, template_file=None):
     """Generate Excel-file (output) from styled Panda's dataframe."""
-
-
     # Add autofilters to Excel sheet
-    writer = pd.ExcelWriter(output, engine='openpyxl') # pylint: disable=abstract-class-instantiated
+    # pylint: disable=abstract-class-instantiated
+    writer = pd.ExcelWriter(output, engine="openpyxl")
 
     if template_file:
         template_book = load_workbook(template_file)
@@ -317,7 +439,7 @@ def generate_excel(output, styled, template_file=None):
     workbook = writer.book
     worksheet = workbook[_DATA_SHEET_NAME]
 
-    #put the datasheet first, _sheets is protected
+    # put the datasheet first, _sheets is protected
     # pylint: disable=W0212
     oldindex = workbook._sheets.index(worksheet)
     # pylint: disable=W0212
@@ -331,21 +453,22 @@ def generate_excel(output, styled, template_file=None):
     for cell in worksheet[1]:
         colum_names.append(str(cell.value))
 
-    #set default width of colums to match the title
-    for col in range(worksheet.min_column, worksheet.max_column+1):
-        worksheet.column_dimensions[get_column_letter(col)].width = len(colum_names[col-1])+5
+    # set default width of colums to match the title
+    for col in range(worksheet.min_column, worksheet.max_column + 1):
+        worksheet.column_dimensions[get_column_letter(col)].width = (
+            len(colum_names[col - 1]) + 5
+        )
 
     writer.save()
+
 
 #
 # style_single_cell - set background color on a cell
 #
 def style_single_cell(work_sheet, row, column, color):
-
     """Set a single cell to a specific color."""
-
     new_color = f"background-color:  {color}"
-    df1 = pd.DataFrame('', index=work_sheet.index, columns=work_sheet.columns)
+    df1 = pd.DataFrame("", index=work_sheet.index, columns=work_sheet.columns)
     df1.iloc[row, column] = new_color
     return df1
 
@@ -357,8 +480,10 @@ def _parse_args():
     # Two command modes, list and change
 
     subparsers = parser.add_subparsers(dest="command")
-    parser_list = subparsers.add_parser("list",
-        help="Create CSV and Excel-file of Yocto License manifest file.")
+    parser_list = subparsers.add_parser(
+        "list",
+        help="Create CSV and Excel-file of Yocto License manifest file.",
+    )
     parser_list.add_argument(
         "inputfile",
         help="Yocto license manifest file name (used as input)",
@@ -368,8 +493,11 @@ def _parse_args():
         help="Name base for CSV/Excel-formatted output list file name, i.e."
         " <listfile>.csv/.xlsx",
     )
-    parser_changes = subparsers.add_parser("changes",
-        help="Create changes highlighting list from two Yocto license manifest files.")
+    parser_changes = subparsers.add_parser(
+        "changes",
+        help="Create changes highlighting list from two Yocto license "
+        "manifest files.",
+    )
     parser_changes.add_argument(
         "previous",
         help="Previous Yocto license manifest file name",
@@ -383,73 +511,88 @@ def _parse_args():
         help="Name base for CSV/Excel-formatted changes file name, i.e."
         " <changefile>.csv/.xlsx",
     )
-    parser.add_argument("--force",
+    parser.add_argument(
+        "--force",
         help="Force overwrite of existing output file",
-        action='store_true'
+        action="store_true",
     )
-    parser.add_argument("--verbose",
+    parser.add_argument(
+        "--verbose",
         help="Verbose diagnostics",
         action="store_const",
         dest="loglevel",
-        const=logging.INFO
+        const=logging.INFO,
     )
-    parser.add_argument("--debug",
+    parser.add_argument(
+        "--debug",
         help="Extra diagnostic output",
         action="store_const",
         dest="loglevel",
         const=logging.DEBUG,
-        default=logging.WARNING
+        default=logging.WARNING,
     )
     args, unknown = parser.parse_known_args()
-    logging.basicConfig(level=args.loglevel,format='')
+    logging.basicConfig(level=args.loglevel, format="")
     if not args.command:
         _print_help()
         sys.exit(0)
 
     if len(unknown) > 0:
         logging.error("unsupported arguments: %s ", str(unknown))
-        sys.exit(8) # ENOEXEC
+        sys.exit(8)  # ENOEXEC
     return args
+
 
 # parse_list - handle the case of list option sanitizing/checking
 #
 def parse_list(args):
-
     """Parse arguments in case of list -option/command given."""
-
     if not os.path.isfile(args.inputfile):
         print("ERROR - input file: '" + args.inputfile + "' does not exist.")
-        sys.exit(2) # ENOENT
-    if os.path.isfile(args.listfile + _CSV) or os.path.isfile(args.listfile + _XLS):
+        sys.exit(2)  # ENOENT
+    if os.path.isfile(args.listfile + _CSV) or os.path.isfile(
+        args.listfile + _XLS
+    ):
         if not args.force:
             print("ERROR - output file: '" + args.listfile + _EXISTS)
             sys.exit(2)  # ENOENT
         else:
-            print("Warning - output file: '" + args.listfile + _EXISTS + _OVERWRITE)
+            print(
+                "Warning - output file: '"
+                + args.listfile
+                + _EXISTS
+                + _OVERWRITE
+            )
     gen_list(args.inputfile, args.listfile)
+
 
 # parse_changes - handle the case of changes option sanitizing/checking
 #
 def parse_changes(args):
-
     """Parse arguments in case of change -option/command given."""
-
     if not os.path.isfile(args.previous):
         print("ERROR - previous license file: '" + args.previous + _NOT_EXIST)
-        sys.exit(2) # ENOENT
+        sys.exit(2)  # ENOENT
     if not os.path.isfile(args.current):
         print("ERROR - current license file: '" + args.current + _NOT_EXIST)
-        sys.exit(2) # ENOENT
-    if os.path.isfile(args.changefile + _CSV) or os.path.isfile(args.changefile + _XLS):
+        sys.exit(2)  # ENOENT
+    if os.path.isfile(args.changefile + _CSV) or os.path.isfile(
+        args.changefile + _XLS
+    ):
         if not args.force:
             print("ERROR - output file: '" + args.changefile + _EXISTS)
             sys.exit(2)  # ENOENT
         else:
-            print("Warning - output file: '" + args.changefile + _EXISTS + _OVERWRITE)
+            print(
+                "Warning - output file: '"
+                + args.changefile
+                + _EXISTS
+                + _OVERWRITE
+            )
     gen_changes(args.previous, args.current, args.changefile)
 
-def main():
 
+def main():
     """Script entry point."""
     args = _parse_args()
     if args.command == "list":
@@ -457,6 +600,7 @@ def main():
 
     if args.command == "changes":
         parse_changes(args)
+
 
 if __name__ == "__main__":
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 # Copyright (c) 2021, Pelion Limited and affiliates.
+# Copyright 2022 Izuma Networks
+#
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +17,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+"""Licensetool setup.py."""
+
+
 from setuptools import setup
 
-setup(name='licensetool')
+setup(name="licensetool")

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -3,6 +3,9 @@
 # licensetool.py / test_changes.py
 #
 # Copyright (c) 2021, Pelion Limited and affiliates.
+# Copyright (c) 2022 Izuma Networks
+#
+#
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,67 +20,107 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 """Licensetool test cases for the changes argument/functionality."""
 
+import sys
 import os
+from pathlib import Path
 import pandas as pd
-from licensetool import _DATA_SHEET_NAME
 
-_PY_LCTOOL_CHANGES_PACK = "python licensetool.py changes tests/3-packages.manifest "
+_PY_LCTOOL_CHANGES_PACK = (
+    "python licensetool.py changes tests/3-packages.manifest "
+)
+
+# Workaround for the module not found problem,
+# tests will at least run with Python 3.10.
+file = Path(__file__).resolve()
+parent, root = file.parent, file.parents[1]
+sys.path.append(str(root))
+
+# pylint: disable=wrong-import-position
+from licensetool import _DATA_SHEET_NAME  # noqa
+
 
 # Test previous empty file
 def test_empty_license_prev(tmpdir):
     """Test with empty 1st file (fail)"""
     tmp_outfiles = str(tmpdir.join("out"))
-    ret = os.system("python licensetool.py changes tests/empty_file.manifest "
-                    "tests/3-packages.manifest.v2 " + tmp_outfiles)
+    ret = os.system(
+        "python licensetool.py changes tests/empty_file.manifest "
+        "tests/3-packages.manifest.v2 " + tmp_outfiles
+    )
     assert ret != 0
+
 
 # Test empty current file
 def test_empty_license_curr(tmpdir):
     """Test with empty 2nd input file (fail)"""
     tmp_outfiles = str(tmpdir.join("out"))
-    ret = os.system(_PY_LCTOOL_CHANGES_PACK + "tests/empty_file.manifest " + tmp_outfiles)
+    ret = os.system(
+        _PY_LCTOOL_CHANGES_PACK + "tests/empty_file.manifest " + tmp_outfiles
+    )
     assert ret != 0
+
 
 # If output file exists, it should refuse to overwrite
 def test_outfile_exists(tmpdir):
-    """Test overwrite protection (fail, will not overwrite without --force option)"""
+    """
+    Test overwrite protection (fail, will not overwrite without --force option)
+    """
     tmp_outfiles = str(tmpdir.join("out"))
     # 1st run - create the file out.csv/.xlsx
-    ret = os.system(_PY_LCTOOL_CHANGES_PACK + "tests/3-packages.manifest.v2 " + tmp_outfiles)
+    ret = os.system(
+        _PY_LCTOOL_CHANGES_PACK
+        + "tests/3-packages.manifest.v2 "
+        + tmp_outfiles
+    )
     assert ret == 0
     # 2nd run must fail, files now already exist (out.csv/out.xlsx)
-    ret = os.system(_PY_LCTOOL_CHANGES_PACK + "tests/3-packages.manifest.v2 " + tmp_outfiles)
+    ret = os.system(
+        _PY_LCTOOL_CHANGES_PACK
+        + "tests/3-packages.manifest.v2 "
+        + tmp_outfiles
+    )
     assert ret != 0
+
 
 # Invalid previous
 def test_invalid_previous(tmpdir):
     """Test with broken 1st input file (fail)"""
     tmp_outfiles = str(tmpdir.join("out"))
-    ret = os.system("python licensetool.py changes tests/broken.manifest "
-                    "tests/3-packages.manifest " + tmp_outfiles)
+    ret = os.system(
+        "python licensetool.py changes tests/broken.manifest "
+        "tests/3-packages.manifest " + tmp_outfiles
+    )
     assert ret != 0
+
 
 # Invalid current
 def test_invalid_current(tmpdir):
     """Test with broken 2nd input file (fail)"""
     tmp_outfiles = str(tmpdir.join("out"))
-    ret = os.system(_PY_LCTOOL_CHANGES_PACK + "tests/broken.manifest " + tmp_outfiles)
+    ret = os.system(
+        _PY_LCTOOL_CHANGES_PACK + "tests/broken.manifest " + tmp_outfiles
+    )
     assert ret != 0
+
 
 # Success case
 def test_changes_v1_v2(tmpdir):
     """Test normal success case (success)"""
     tmp_outfiles = str(tmpdir.join("out"))
-    ret = os.system("python licensetool.py changes tests/changes-test.v1 "
-                    "tests/changes-test.v2 " + tmp_outfiles)
+    ret = os.system(
+        "python licensetool.py changes tests/changes-test.v1 "
+        "tests/changes-test.v2 " + tmp_outfiles
+    )
     assert ret == 0
     # Compare result, too
     ref_df = pd.read_csv("tests/test-changes.csv")
     result_df = pd.read_csv(tmp_outfiles + ".csv")
     assert result_df.equals(ref_df)
     # Also the Excel-version
-    xl_result_df = pd.read_excel(tmp_outfiles + ".xlsx", sheet_name=_DATA_SHEET_NAME,
-                                 engine='openpyxl')
+    xl_result_df = pd.read_excel(
+        tmp_outfiles + ".xlsx", sheet_name=_DATA_SHEET_NAME, engine="openpyxl"
+    )
     assert xl_result_df.equals(ref_df)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,8 @@
 # test_cli - test the command line interface (i.e. argument parsing)
 #
 # Copyright (c) 2021, Pelion Limited and affiliates.
+# Copyright (c) 2022 Izuma Networks
+#
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,41 +24,54 @@
 import os
 
 # SonarQube duplication fix - success case as literal
-_PY_LCTOOL_LIST_3MANIFESTS  = "python licensetool.py list tests/3-packages.manifest "
-_PY_LCTOOL_CHG_3MANIFESTS = "python licensetool.py changes tests/3-packages.manifest " \
-                            "tests/3-packages.manifest.v2 "
+_PY_LCTOOL_LIST_3MANIFESTS = (
+    "python licensetool.py list tests/3-packages.manifest "
+)
+_PY_LCTOOL_CHG_3MANIFESTS = (
+    "python licensetool.py changes tests/3-packages.manifest "
+    "tests/3-packages.manifest.v2 "
+)
+
 
 def test_no_params():
     """Test with no parameters (success, print help)"""
     ret = os.system("python licensetool.py")
     assert ret == 0
 
+
 def test_list_only():
     """Test with list argument only (fail)"""
     ret = os.system("python licensetool.py list")
     assert ret != 0
+
 
 def test_list_non_valid_option():
     """Test with non-valid option (fail)"""
     ret = os.system("python licensetool.py list --nonvalidoption")
     assert ret != 0
 
+
 def test_list_input_only():
     """Test with list and only input file (fail)"""
-    ret = os.system(_PY_LCTOOL_LIST_3MANIFESTS )
+    ret = os.system(_PY_LCTOOL_LIST_3MANIFESTS)
     assert ret != 0
+
 
 def test_list_input_output(tmpdir):
     """Test list with input and valid output (success)"""
     tmp_outfilebase = str(tmpdir.join("out"))
-    ret = os.system(_PY_LCTOOL_LIST_3MANIFESTS  + tmp_outfilebase)
+    ret = os.system(_PY_LCTOOL_LIST_3MANIFESTS + tmp_outfilebase)
     assert ret == 0
+
 
 def test_list_input_missing(tmpdir):
     """Test list with non-existent input file (fail)"""
     tmp_outfilebase = str(tmpdir.join("out"))
-    ret = os.system("python licensetool.py list non-existent-file " + tmp_outfilebase)
+    ret = os.system(
+        "python licensetool.py list non-existent-file " + tmp_outfilebase
+    )
     assert ret != 0
+
 
 def test_list_extra_param_at_end(tmpdir):
     """Test list with extra parameter at end (fail)"""
@@ -64,69 +79,92 @@ def test_list_extra_param_at_end(tmpdir):
     ret = os.system(_PY_LCTOOL_LIST_3MANIFESTS + tmp_outfilebase + " extra")
     assert ret != 0
 
+
 def test_list_broken_manifest(tmpdir):
     """Test list with broken input file (fail)"""
     tmp_outfilebase = str(tmpdir.join("out"))
-    ret = os.system("python licensetool.py list tests/broken.manifest " + tmp_outfilebase)
+    ret = os.system(
+        "python licensetool.py list tests/broken.manifest " + tmp_outfilebase
+    )
     assert ret != 0
+
 
 def test_list_output_existing(tmpdir):
     """Test list with output file already existing (fail, don't overwrite)"""
     tmp_outfile = str(tmpdir.join("out"))
-    ret = os.system(_PY_LCTOOL_LIST_3MANIFESTS  + tmp_outfile)
+    ret = os.system(_PY_LCTOOL_LIST_3MANIFESTS + tmp_outfile)
     # 1st time should pass.
     assert ret == 0
     # 2nd time must fail
-    ret = os.system(_PY_LCTOOL_LIST_3MANIFESTS  + tmp_outfile)
+    ret = os.system(_PY_LCTOOL_LIST_3MANIFESTS + tmp_outfile)
     assert ret != 0
+
 
 def test_list_forced_overwrite(tmpdir):
     """Test list with forced overwrite input and valid output (success)"""
     tmp_outfilebase = str(tmpdir.join("out"))
-    ret = os.system(_PY_LCTOOL_LIST_3MANIFESTS  + tmp_outfilebase)
+    ret = os.system(_PY_LCTOOL_LIST_3MANIFESTS + tmp_outfilebase)
     # This creates now out.csv and out.xlsx
     assert ret == 0
     # Now overwrite them
-    ret = os.system("python licensetool.py --force list tests/3-packages.manifest "
-     + tmp_outfilebase)
+    ret = os.system(
+        "python licensetool.py --force list tests/3-packages.manifest "
+        + tmp_outfilebase
+    )
     assert ret == 0
+
 
 def test_changes_only():
     """Test w changes option only (fail)"""
     ret = os.system("python licensetool.py changes")
     assert ret != 0
 
+
 def test_changes_input2_missing():
     """Test w changes option and one input file only (fail)"""
     ret = os.system("python licensetool.py changes tests/3-packages.manifest ")
     assert ret != 0
 
+
 def test_changes_output_missing():
     """Test w changes option and one input file only (fail)"""
-    ret = os.system("python licensetool.py changes tests/3-packages.manifest "
-                    "tests/3-packages.manifest.v2")
+    ret = os.system(
+        "python licensetool.py changes tests/3-packages.manifest "
+        "tests/3-packages.manifest.v2"
+    )
     assert ret != 0
+
 
 def test_changes_input1_not_existing(tmpdir):
     """Test w changes option and non-existent input file (fail)"""
     tmp_outfile = str(tmpdir.join("out"))
-    ret = os.system("python licensetool.py changes non-existent-file tests/3-packages.manifest.v2 "
-                    + tmp_outfile)
+    ret = os.system(
+        "python licensetool.py changes non-existent-file"
+        " tests/3-packages.manifest.v2 " + tmp_outfile
+    )
     assert ret != 0
+
 
 def test_changes_input2_not_existing(tmpdir):
     """Test w changes option and non-existent 2nd input file (fail)"""
     tmp_outfile = str(tmpdir.join("out"))
-    ret = os.system("python licensetool.py changes tests/3-packages.manifest non-existent-file2 "
-                    + tmp_outfile)
+    ret = os.system(
+        "python licensetool.py changes tests/3-packages.manifest"
+        " non-existent-file2 " + tmp_outfile
+    )
     assert ret != 0
+
 
 def test_changes_unknown_option(tmpdir):
     """Test w changes option and unknown option (fail)"""
     tmp_outfile = str(tmpdir.join("out"))
-    ret = os.system("python licensetool.py --unknownoption changes tests/3-packages.manifest "
-                    "tests/3-packages.manifest.v2 " + tmp_outfile)
+    ret = os.system(
+        "python licensetool.py --unknownoption changes "
+        " tests/3-packages.manifest tests/3-packages.manifest.v2 "
+        + tmp_outfile
+    )
     assert ret != 0
+
 
 def test_changes_extra_param_at_end(tmpdir):
     """Test w changes extra parameter in the end (fail)"""
@@ -141,6 +179,7 @@ def test_changes_input_ok_output(tmpdir):
     ret = os.system(_PY_LCTOOL_CHG_3MANIFESTS + tmp_outfile)
     assert ret == 0
 
+
 def test_changes_output_existing(tmpdir):
     """Output existing, will not overwrite (fail)"""
     tmp_outfile = str(tmpdir.join("out"))
@@ -151,6 +190,7 @@ def test_changes_output_existing(tmpdir):
     ret = os.system(_PY_LCTOOL_CHG_3MANIFESTS + tmp_outfile)
     assert ret != 0
 
+
 def test_changes_forced_overwrite(tmpdir):
     """Output existing, forced overwrite (success)"""
     tmp_outfile = str(tmpdir.join("out"))
@@ -158,7 +198,8 @@ def test_changes_forced_overwrite(tmpdir):
     # This creates now out.csv and out.xlsx
     assert ret == 0
     # Now overwrite them
-    ret = os.system("python licensetool.py --force changes "
-                    "tests/3-packages.manifest tests/3-packages.manifest.v2 "
-                     + tmp_outfile)
+    ret = os.system(
+        "python licensetool.py --force changes "
+        "tests/3-packages.manifest tests/3-packages.manifest.v2 " + tmp_outfile
+    )
     assert ret == 0

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -3,6 +3,8 @@
 # licensetool.py
 #
 # Copyright (c) 2021, Pelion Limited and affiliates.
+# Copyright (c) 2022 Izuma Networks
+#
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,12 +19,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 """Licensetool test cases for the list command argument."""
 
+
+import sys
 import os
+from pathlib import Path
 import pandas as pd
-import licensetool as t
-from licensetool import _DATA_SHEET_NAME
+
+# Workaround for the module not found problem,
+# tests will at least run with Python 3.10.
+file = Path(__file__).resolve()
+parent, root = file.parent, file.parents[1]
+sys.path.append(str(root))
+
+# noqa
+# pylint: disable=wrong-import-position
+import licensetool as t  # noqa
+from licensetool import _DATA_SHEET_NAME  # noqa
+
 
 # Test empty file
 def test_empty_license():
@@ -31,6 +47,7 @@ def test_empty_license():
     assert status["errors"] is True
     assert d_f.empty is True
 
+
 # Test each of the lines (package, package version, recipe, license) missing
 def test_no_line1():
     """Line1 (package) missing from manifest file (fail)."""
@@ -38,11 +55,13 @@ def test_no_line1():
     assert status["errors"] is True
     assert d_f.empty is True
 
+
 def test_no_line2():
     """Line2 missing from manifest file (fail)."""
     d_f, status = t.read_manifest_file("tests/no-line2.manifest")
     assert status["errors"] is True
     assert d_f.empty is True
+
 
 def test_no_line3():
     """Line3 missing from manifest file (fail)."""
@@ -50,23 +69,27 @@ def test_no_line3():
     assert status["errors"] is True
     assert d_f.empty is True
 
+
 def test_no_line4():
     """Line4 missing from manifest file (fail)."""
     d_f, status = t.read_manifest_file("tests/no-line4.manifest")
     assert status["errors"] is True
     assert d_f.empty is True
 
+
 def test_out_of_sync():
     """Out of sync error case in manifest file (fail)."""
     d_f, status = t.read_manifest_file("tests/out-of-sync.manifest")
     assert status["errors"] is True
-    assert d_f.empty is False    # There will be one entry in the DataFrame
+    assert d_f.empty is False  # There will be one entry in the DataFrame
+
 
 def test_broken_manifest():
     """Broken/malformatted manifest file (fail)."""
     d_f, status = t.read_manifest_file("tests/broken.manifest")
     assert status["errors"] is True
     assert d_f.empty is True
+
 
 # Test a known successfull cases, with 3 packages only.
 def test_3_packages():
@@ -79,22 +102,27 @@ def test_3_packages():
     ref_d_f = pd.read_csv("tests/3-packages.csv")
     assert d_f.equals(ref_d_f)
 
+
 # Test a known successfull cases, with 3 packages only - via cli
 # so that we can verify also the xlsx -version.
 def test_3_packages_cli(tmpdir):
     """Normal success case with 3 packages via cli (success)"""
     # Also via cli for the Excel-version, too
     tmp_outfile = str(tmpdir.join("out"))
-    ret = os.system("python licensetool.py list tests/3-packages.manifest " + tmp_outfile )
+    ret = os.system(
+        "python licensetool.py list tests/3-packages.manifest " + tmp_outfile
+    )
     assert ret == 0
     # Compare result, too
     ref_d_f = pd.read_csv("tests/3-packages.csv")
-    result_d_f = pd.read_csv(tmp_outfile+".csv")
+    result_d_f = pd.read_csv(tmp_outfile + ".csv")
     assert result_d_f.equals(ref_d_f)
     # Also the Excel-version
-    xl_result_d_f = pd.read_excel(tmp_outfile+".xlsx", sheet_name=_DATA_SHEET_NAME,
-                                  engine='openpyxl')
+    xl_result_d_f = pd.read_excel(
+        tmp_outfile + ".xlsx", sheet_name=_DATA_SHEET_NAME, engine="openpyxl"
+    )
     assert xl_result_d_f.equals(ref_d_f)
+
 
 # No empty lines at the end eg. broken package
 def test_3_packages_noemptylines():


### PR DESCRIPTION
- `pysh-check` compliancy (formatting).
- Python 3.10 compatibility issues with module visibility. 
    - Have to silence wrong-import-order to get pylint to pass.
- Enbable `pysh-check` test in PR-checker.
