### PR TITLE
Python 3.10 - 3.13, restructure, tox

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -1,29 +1,16 @@
 name: PR-check
 run-name: ${{ github.actor }} PR checker
-on: [push]
+on:
+  push:
+  workflow_dispatch:
 jobs:
   run-pytest-pylint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y build-essential python3-pandas
       - run: pip install -r requirements.txt
       - run: pip install -r dev-requirements.txt
       - run: pip install --editable .
       - run: pytest -v -o junit_family=xunit1 --cov=. --cov-report xml:coverage.xml --cov-report html:test-results/cov_html --junitxml=xunit-reports/xunit.xml
       - run: pylint licensetool.py tests/*.py
-  run-pysh-check:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      # Install pyshcheck tooling
-      - run: sudo apt install pycodestyle pydocstyle black
-      # git instead of rules to use access token
-      - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
-      - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
-      - run: git config --list
-      - run: git clone git@github.com:PelionIoT/scripts-internal.git
-      - run: echo "." >scripts-internal/.nopyshcheck
-      - run: scripts-internal/pysh-check/pysh-check.sh --workdir .
-      - name: Clean up .gitconfig
-        if: always()
-        run: rm -f ~/.gitconfig

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -4,13 +4,22 @@ on:
   push:
   workflow_dispatch:
 jobs:
-  run-pytest-pylint:
+  run-tox:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get update && sudo apt-get install -y build-essential python3-pandas
-      - run: pip install -r requirements.txt
-      - run: pip install -r dev-requirements.txt
-      - run: pip install --editable .
-      - run: pytest -v -o junit_family=xunit1 --cov=. --cov-report xml:coverage.xml --cov-report html:test-results/cov_html --junitxml=xunit-reports/xunit.xml
-      - run: pylint licensetool.py tests/*.py
+      - uses: actions/setup-python@v5 
+        with:
+         python-version: '3.10'
+      - uses: actions/setup-python@v5 
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-python@v5 
+        with:
+          python-version: '3.12'
+      - run: python -m pip install --upgrade pip
+      - name: Install tox
+        run: | 
+          pipx install tox
+      - run: ./dev-init.sh
+      - run: tox

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/setup-python@v5 
         with:
           python-version: '3.12'
+      - uses: actions/setup-python@v5 
+        with:
+          python-version: '3.13'
       - run: python -m pip install --upgrade pip
       - name: Install tox
         run: | 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ LicenseTool is a Python program that has two primary functions:
 
 ## Installation
 
-You need to have Python version 3.6 (or newer) installed in your system. This has only been tested in Linux, we do not plan to test or support Windows or Mac platforms in any way or manner as Yocto builds are done on Linux anyway.
+You need to have Python version 3.10 (or newer) installed in your system. This has only been tested in Linux, we do not plan to test or support Windows or Mac platforms in any way or manner as Yocto builds are done on Linux anyway.
 
 We highly recommend using a [Python virtual environment](https://docs.python.org/3/tutorial/venv.html).
 
-Python 3.10 will give you unfortunately a lot of warnings. They just love deprecating APIs in the Python world, don't they?
+If you need to use older versions of Python (3.6 - 3.9), use `v1.0` of this tool.
 
 ## User installation
 
@@ -24,7 +24,7 @@ git clone git@github.com:PelionIoT/licensetool.git
 cd licensetool
 python3 -m venv venv
 source venv/bin/activate
-pip install -r requirements.txt
+pip install .
 ```
 
 ## Developer installation
@@ -42,7 +42,7 @@ The license file is generated as part of the Yocto build. In Foundries.io LmP-bu
 
 ### Generate CSV-formatted license file
 
-`python licensetool.py list <input manifest file> <output>`
+`licensetool list <input manifest file> <output>`
 
 This will generate two output files,
 
@@ -51,7 +51,7 @@ This will generate two output files,
 
 ### Generate license changes file
 
-`python licensetool.py changes <previous manifest file> <current manifest file> <output file>`
+`licensetool changes <previous manifest file> <current manifest file> <output file>`
 
 This will generate two output files,
 
@@ -60,15 +60,19 @@ This will generate two output files,
 
 ### Other options
 
-Run the tool with `python licensetool.py` to get information on optional parameters.
+Run the tool with `licensetool` to get information on optional parameters.
 
 ## Tests
 
 Tests and test material are located in [tests](tests)-folder.
 You can run them from the root folder:
 
+```bash
+tox
 ```
-pytest -v -o junit_family=xunit1 --cov=. --cov-report xml:coverage.xml --cov-report html:test-results/cov_html --junitxml=xunit-reports/xunit.xml
+or just directly for just one Python-version.
+```bash
+pytest -v
 ```
 
 ## Contributions
@@ -76,6 +80,6 @@ pytest -v -o junit_family=xunit1 --cov=. --cov-report xml:coverage.xml --cov-rep
 All contributions must pass:
 - Clear written statement that author agrees to Apache 2.0 license and is the original author of the changes.
 - Code review, so submit a pull request (PR).
-- Run `pylint licensetool.py tests/*.py` and make sure the score does not get worse (10/10 now).
+- Run `tox` and make sure the score does not get worse (10/10 now).
 - Include necessary test case updates, so that coverage does not decrease - provide evidence in the PR.
 - Include required documentation updates.

--- a/dev-init.sh
+++ b/dev-init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 # ----------------------------------------------------------------------------
 # Copyright 2021 Pelion
-# Copyright 2021 Izuma Networks
+# Copyright 2022-2025 Izuma Networks
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -19,6 +19,11 @@
 # ----------------------------------------------------------------------------
 set -ex
 
+# Tox needs pipx
+if ! command -v pipx &> /dev/null; then
+    pip install pipx
+fi
+
 # Create virtual environment if one is not in place
 if [[ ! -d venv ]]; then
     python3 -m venv venv
@@ -30,7 +35,9 @@ source venv/bin/activate
 if [[ $(pip show licensetool) ]]; then
     pip uninstall licensetool --yes
 fi
-pip install --editable .
 
-pip install -r requirements.txt
-pip install -r dev-requirements.txt
+if ! command -v tox &> /dev/null; then
+    pipx install tox
+fi
+pip install --editable ".[dev]"
+

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,1 @@
-pylint==2.11.0
-pytest
-pytest-mock
-pytest-cov
-tox
-pycodestyle
-coverage
-wheel
-bandit
+-e .[dev]

--- a/licensetool.py
+++ b/licensetool.py
@@ -122,13 +122,13 @@ def read_manifest_file(input_file):
                 errors = True
             prew = info_field.span()[1]
 
-            new_row = {
-                column_names[0]: info_field.group(1),
-                column_names[1]: info_field.group(2),
-                column_names[2]: info_field.group(3),
-                column_names[3]: info_field.group(4),
-            }
-            d_f = d_f.append(new_row, ignore_index=True)
+            new_row = pd.DataFrame([[
+                info_field.group(1),
+                info_field.group(2),
+                info_field.group(3),
+                info_field.group(4),
+            ]], columns=column_names)
+            d_f = pd.concat([d_f, new_row], ignore_index=True)
 
         if (
             package_count == 0

--- a/licensetool/licensetool/__init__.py
+++ b/licensetool/licensetool/__init__.py
@@ -1,6 +1,6 @@
-# ----------------------------------------------------------------------------
-# Copyright 2021 Pelion
-# Copyright 2025 Izuma Networks
+#!/usr/bin/env python3
+#
+# Copyright (c) 2024 Izuma Networks
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -15,6 +15,32 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ----------------------------------------------------------------------------
 
-__version__ = "1.0.0"
+"""
+A tool for dealing with Yocto license manifest files.
+
+This tool can converting them to CSV/Excel-format,
+optionally with change information. 
+
+This file has the (global) imports required by the tests.
+Actual values defiend in main.py
+"""
+
+
+
+from .main import (
+    read_manifest_file,
+    gen_list,
+    gen_changes,
+    _DATA_SHEET_NAME,
+    main,
+)
+
+
+__all__ = [
+    'read_manifest_file',
+    'gen_list',
+    'gen_changes',
+    '_DATA_SHEET_NAME',
+    'main',
+]

--- a/licensetool/licensetool/main.py
+++ b/licensetool/licensetool/main.py
@@ -32,8 +32,16 @@ import logging
 import argparse
 import re
 import pandas as pd
-from openpyxl.utils import get_column_letter
 from openpyxl import load_workbook
+
+# Public functions/constants so that tests find
+__all__ = [
+    'read_manifest_file',
+    '_DATA_SHEET_NAME',
+    'gen_list',
+    'gen_changes',
+    # Add other public functions/constants here
+]
 
 # Lots of literals
 _CSV = ".csv"
@@ -130,9 +138,8 @@ def read_manifest_file(input_file):
             ]], columns=column_names)
             d_f = pd.concat([d_f, new_row], ignore_index=True)
 
-        if (
-            package_count == 0
-        ):  # needs to have at least one package or it is an error
+        # Needs to have at least one package or it is an error
+        if package_count == 0:
             print("Package count is zero")
             errors = True
 
@@ -324,8 +331,9 @@ def gen_changes(previous, current, output):
             package_change = True
             change_summary[_PKG_ADD] += 1
         # Package removed
-        if package_change is False and pd.isna(
-            d_f_combo.at[i, _CURR_REC]
+        if (
+                package_change is False and
+                pd.isna(d_f_combo.at[i, _CURR_REC])
         ):  # NaN
             d_f_combo.at[i, _CHG] = _MARK_CHG
             d_f_combo.at[i, _PKG_REM] = _MARK_CHG
@@ -361,8 +369,8 @@ def gen_changes(previous, current, output):
             change_summary[_PKG_REM] += 1
         # Version change
         if (
-            package_change is False
-            and d_f_combo.at[i, _PREV_VER] != d_f_combo.at[i, _CURR_VER]
+                package_change is False
+                and d_f_combo.at[i, _PREV_VER] != d_f_combo.at[i, _CURR_VER]
         ):
             d_f_combo.at[i, _CHG] = _MARK_CHG
             d_f_combo.at[i, _VER_CHG] = _MARK_CHG
@@ -383,8 +391,8 @@ def gen_changes(previous, current, output):
             change_summary[_VER_CHG] += 1
         # License change
         if (
-            package_change is False
-            and d_f_combo.at[i, _PREV_LIC] != d_f_combo.at[i, _CURR_LIC]
+                package_change is False
+                and d_f_combo.at[i, _PREV_LIC] != d_f_combo.at[i, _CURR_LIC]
         ):
             d_f_combo.at[i, _CHG] = _MARK_CHG
             d_f_combo.at[i, _LIC_CHG] = _MARK_CHG
@@ -423,43 +431,46 @@ def gen_changes(previous, current, output):
 #                  styled = styled Pandas dataframe
 #
 def generate_excel(output, styled, template_file=None):
-    """Generate Excel-file (output) from styled Panda's dataframe."""
-    # Add autofilters to Excel sheet
-    # pylint: disable=abstract-class-instantiated
-    writer = pd.ExcelWriter(output, engine="openpyxl")
-
-    if template_file:
+    """Generate Excel file from dataframe."""
+    if template_file and os.path.exists(template_file):
+        # Load template if it exists
         template_book = load_workbook(template_file)
-        writer.book = template_book
 
-    styled.to_excel(writer, sheet_name=_DATA_SHEET_NAME, index=False)
-
-    # Get the xlsxwriter workbook and worksheet objects.
-    # pylint: disable=E1101
-    workbook = writer.book
-    worksheet = workbook[_DATA_SHEET_NAME]
-
-    # put the datasheet first, _sheets is protected
-    # pylint: disable=W0212
-    oldindex = workbook._sheets.index(worksheet)
-    # pylint: disable=W0212
-    workbook._sheets.pop(oldindex)
-    # pylint: disable=W0212
-    workbook._sheets.insert(0, worksheet)
-
-    worksheet.auto_filter.ref = worksheet.dimensions
-
-    colum_names = []
-    for cell in worksheet[1]:
-        colum_names.append(str(cell.value))
-
-    # set default width of colums to match the title
-    for col in range(worksheet.min_column, worksheet.max_column + 1):
-        worksheet.column_dimensions[get_column_letter(col)].width = (
-            len(colum_names[col - 1]) + 5
+        # Write the main data sheet using pandas to_excel directly
+        styled.to_excel(
+            output,
+            sheet_name=_DATA_SHEET_NAME,
+            engine='openpyxl',
+            index=False
         )
 
-    writer.save()
+        # Load the written file to add template sheets
+        workbook = load_workbook(output)
+
+        # Copy sheets from template
+        for sheet_name in template_book.sheetnames:
+            if sheet_name != _DATA_SHEET_NAME:
+                # Copy sheet from template
+                template_sheet = template_book[sheet_name]
+                if sheet_name not in workbook.sheetnames:
+                    workbook.create_sheet(sheet_name)
+                dest_sheet = workbook[sheet_name]
+
+                # Copy content
+                for row in template_sheet.rows:
+                    for cell in row:
+                        dest_sheet[cell.coordinate] = cell.value
+                dest_sheet.sheet_state = 'visible'
+        # Save the workbook
+        workbook.save(output)
+    else:
+        # Just write the dataframe if no template
+        styled.to_excel(
+            output,
+            sheet_name=_DATA_SHEET_NAME,
+            engine='openpyxl',
+            index=False
+        )
 
 
 #
@@ -550,8 +561,9 @@ def parse_list(args):
     if not os.path.isfile(args.inputfile):
         print("ERROR - input file: '" + args.inputfile + "' does not exist.")
         sys.exit(2)  # ENOENT
-    if os.path.isfile(args.listfile + _CSV) or os.path.isfile(
-        args.listfile + _XLS
+    if (
+            os.path.isfile(args.listfile + _CSV) or
+            os.path.isfile(args.listfile + _XLS)
     ):
         if not args.force:
             print("ERROR - output file: '" + args.listfile + _EXISTS)
@@ -576,8 +588,9 @@ def parse_changes(args):
     if not os.path.isfile(args.current):
         print("ERROR - current license file: '" + args.current + _NOT_EXIST)
         sys.exit(2)  # ENOENT
-    if os.path.isfile(args.changefile + _CSV) or os.path.isfile(
-        args.changefile + _XLS
+    if (
+            os.path.isfile(args.changefile + _CSV) or
+            os.path.isfile(args.changefile + _XLS)
     ):
         if not args.force:
             print("ERROR - output file: '" + args.changefile + _EXISTS)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pandas==1.2.5
+pandas==1.5.3
 jinja2
 openpyxl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-pandas==1.5.3
-jinja2
-openpyxl
+-e .

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Copyright (c) 2021, Pelion Limited and affiliates.
-# Copyright 2022 Izuma Networks
+# Copyright 2022-2025 Izuma Networks
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -20,7 +20,31 @@
 
 """Licensetool setup.py."""
 
+from setuptools import setup, find_packages
 
-from setuptools import setup
-
-setup(name="licensetool")
+setup(
+    name="licensetool",
+    version="1.1.0",
+    packages=find_packages(where="licensetool"),
+    package_dir={"": "licensetool"},
+    python_requires=">=3.10",
+    install_requires=[
+        "numpy>=2.2.0,<3.0.0",
+        "pandas>=2.2.3,<3.0.0",
+        "jinja2",
+        "openpyxl",
+    ],
+    extras_require={
+        "dev": [
+            "pytest>=7.4.0",
+            "pytest-cov>=4.1.0",
+            "black",
+            "pylint",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "licensetool=licensetool.main:main",
+        ],
+    },
+)

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -3,7 +3,7 @@
 # licensetool.py / test_changes.py
 #
 # Copyright (c) 2021, Pelion Limited and affiliates.
-# Copyright (c) 2022 Izuma Networks
+# Copyright (c) 2022-2025 Izuma Networks
 #
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -29,7 +29,7 @@ from pathlib import Path
 import pandas as pd
 
 _PY_LCTOOL_CHANGES_PACK = (
-    "python licensetool.py changes tests/3-packages.manifest "
+    "licensetool changes tests/3-packages.manifest "
 )
 
 # Workaround for the module not found problem,
@@ -47,7 +47,7 @@ def test_empty_license_prev(tmpdir):
     """Test with empty 1st file (fail)"""
     tmp_outfiles = str(tmpdir.join("out"))
     ret = os.system(
-        "python licensetool.py changes tests/empty_file.manifest "
+        "licensetool changes tests/empty_file.manifest "
         "tests/3-packages.manifest.v2 " + tmp_outfiles
     )
     assert ret != 0
@@ -90,7 +90,7 @@ def test_invalid_previous(tmpdir):
     """Test with broken 1st input file (fail)"""
     tmp_outfiles = str(tmpdir.join("out"))
     ret = os.system(
-        "python licensetool.py changes tests/broken.manifest "
+        "licensetool changes tests/broken.manifest "
         "tests/3-packages.manifest " + tmp_outfiles
     )
     assert ret != 0
@@ -111,13 +111,21 @@ def test_changes_v1_v2(tmpdir):
     """Test normal success case (success)"""
     tmp_outfiles = str(tmpdir.join("out"))
     ret = os.system(
-        "python licensetool.py changes tests/changes-test.v1 "
+        "licensetool changes tests/changes-test.v1 "
         "tests/changes-test.v2 " + tmp_outfiles
     )
     assert ret == 0
     # Compare result, too
-    ref_df = pd.read_csv("tests/test-changes.csv")
-    result_df = pd.read_csv(tmp_outfiles + ".csv")
+    ref_df = (
+        pd.read_csv("tests/test-changes.csv")
+        .sort_values('Package')
+        .reset_index(drop=True)
+    )
+    result_df = (
+        pd.read_csv(tmp_outfiles + ".csv")
+        .sort_values('Package')
+        .reset_index(drop=True)
+    )
     assert result_df.equals(ref_df)
     # Also the Excel-version
     xl_result_df = pd.read_excel(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@
 # test_cli - test the command line interface (i.e. argument parsing)
 #
 # Copyright (c) 2021, Pelion Limited and affiliates.
-# Copyright (c) 2022 Izuma Networks
+# Copyright (c) 2022-2025 Izuma Networks
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -25,29 +25,29 @@ import os
 
 # SonarQube duplication fix - success case as literal
 _PY_LCTOOL_LIST_3MANIFESTS = (
-    "python licensetool.py list tests/3-packages.manifest "
+    "licensetool list tests/3-packages.manifest "
 )
 _PY_LCTOOL_CHG_3MANIFESTS = (
-    "python licensetool.py changes tests/3-packages.manifest "
+    "licensetool changes tests/3-packages.manifest "
     "tests/3-packages.manifest.v2 "
 )
 
 
 def test_no_params():
     """Test with no parameters (success, print help)"""
-    ret = os.system("python licensetool.py")
+    ret = os.system("licensetool")
     assert ret == 0
 
 
 def test_list_only():
     """Test with list argument only (fail)"""
-    ret = os.system("python licensetool.py list")
+    ret = os.system("licensetool list")
     assert ret != 0
 
 
 def test_list_non_valid_option():
     """Test with non-valid option (fail)"""
-    ret = os.system("python licensetool.py list --nonvalidoption")
+    ret = os.system("licensetool list --nonvalidoption")
     assert ret != 0
 
 
@@ -84,7 +84,7 @@ def test_list_broken_manifest(tmpdir):
     """Test list with broken input file (fail)"""
     tmp_outfilebase = str(tmpdir.join("out"))
     ret = os.system(
-        "python licensetool.py list tests/broken.manifest " + tmp_outfilebase
+        "licensetool list tests/broken.manifest " + tmp_outfilebase
     )
     assert ret != 0
 
@@ -108,7 +108,7 @@ def test_list_forced_overwrite(tmpdir):
     assert ret == 0
     # Now overwrite them
     ret = os.system(
-        "python licensetool.py --force list tests/3-packages.manifest "
+        "licensetool --force list tests/3-packages.manifest "
         + tmp_outfilebase
     )
     assert ret == 0
@@ -116,20 +116,20 @@ def test_list_forced_overwrite(tmpdir):
 
 def test_changes_only():
     """Test w changes option only (fail)"""
-    ret = os.system("python licensetool.py changes")
+    ret = os.system("licensetool changes")
     assert ret != 0
 
 
 def test_changes_input2_missing():
     """Test w changes option and one input file only (fail)"""
-    ret = os.system("python licensetool.py changes tests/3-packages.manifest ")
+    ret = os.system("licensetool changes tests/3-packages.manifest ")
     assert ret != 0
 
 
 def test_changes_output_missing():
     """Test w changes option and one input file only (fail)"""
     ret = os.system(
-        "python licensetool.py changes tests/3-packages.manifest "
+        "licensetool changes tests/3-packages.manifest "
         "tests/3-packages.manifest.v2"
     )
     assert ret != 0
@@ -139,7 +139,7 @@ def test_changes_input1_not_existing(tmpdir):
     """Test w changes option and non-existent input file (fail)"""
     tmp_outfile = str(tmpdir.join("out"))
     ret = os.system(
-        "python licensetool.py changes non-existent-file"
+        "licensetool changes non-existent-file"
         " tests/3-packages.manifest.v2 " + tmp_outfile
     )
     assert ret != 0
@@ -149,7 +149,7 @@ def test_changes_input2_not_existing(tmpdir):
     """Test w changes option and non-existent 2nd input file (fail)"""
     tmp_outfile = str(tmpdir.join("out"))
     ret = os.system(
-        "python licensetool.py changes tests/3-packages.manifest"
+        "licensetool changes tests/3-packages.manifest"
         " non-existent-file2 " + tmp_outfile
     )
     assert ret != 0
@@ -159,7 +159,7 @@ def test_changes_unknown_option(tmpdir):
     """Test w changes option and unknown option (fail)"""
     tmp_outfile = str(tmpdir.join("out"))
     ret = os.system(
-        "python licensetool.py --unknownoption changes "
+        "licensetool --unknownoption changes "
         " tests/3-packages.manifest tests/3-packages.manifest.v2 "
         + tmp_outfile
     )
@@ -199,7 +199,7 @@ def test_changes_forced_overwrite(tmpdir):
     assert ret == 0
     # Now overwrite them
     ret = os.system(
-        "python licensetool.py --force changes "
+        "licensetool --force changes "
         "tests/3-packages.manifest tests/3-packages.manifest.v2 " + tmp_outfile
     )
     assert ret == 0

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -3,7 +3,7 @@
 # licensetool.py
 #
 # Copyright (c) 2021, Pelion Limited and affiliates.
-# Copyright (c) 2022 Izuma Networks
+# Copyright (c) 2022-2025 Izuma Networks
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -23,21 +23,10 @@
 """Licensetool test cases for the list command argument."""
 
 
-import sys
 import os
-from pathlib import Path
 import pandas as pd
-
-# Workaround for the module not found problem,
-# tests will at least run with Python 3.10.
-file = Path(__file__).resolve()
-parent, root = file.parent, file.parents[1]
-sys.path.append(str(root))
-
-# noqa
-# pylint: disable=wrong-import-position
 import licensetool as t  # noqa
-from licensetool import _DATA_SHEET_NAME  # noqa
+from licensetool import _DATA_SHEET_NAME
 
 
 # Test empty file
@@ -110,7 +99,7 @@ def test_3_packages_cli(tmpdir):
     # Also via cli for the Excel-version, too
     tmp_outfile = str(tmpdir.join("out"))
     ret = os.system(
-        "python licensetool.py list tests/3-packages.manifest " + tmp_outfile
+        "licensetool list tests/3-packages.manifest " + tmp_outfile
     )
     assert ret == 0
     # Compare result, too

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310, py311, py312
+envlist = py310, py311, py312, py313
 isolated_build = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,28 @@
+[tox]
+envlist = py310, py311, py312
+isolated_build = True
+
+[testenv]
+deps =
+    -r requirements.txt
+    -r dev-requirements.txt
+
+commands =
+    pytest -v -o junit_family=xunit1 --cov=. --cov-report xml:coverage.xml --cov-report html:test-results/cov_html --junitxml=xunit-reports/xunit.xml
+    pylint licensetool/licensetool/*.py tests/*.py
+
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test
+python_functions = test_*
+
+[coverage:run]
+source = licensetool
+branch = True
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if __name__ == .__main__.:


### PR DESCRIPTION
Python 3.10 / structure fixes / tox introduction

Too large changeset to be honest (for one commit), but
breaking this into smaller ones is a pain, as the
changes depend on each other.

Anyways:
- Proper restructuring so that you can just pip install .
- Add `tox` with tests running in 3.10, 3.11, 3.12 and 3.13.
- Updated pandas and numpy to latest versions.
- Change CI to also use pip install . and tox for testing
- README.md update.

Python 3.8 and 3.9 have now been dropped. If you need them,
use v1.0 version of this tool.
